### PR TITLE
Remove type != "image" check in SanityType.Image decoder

### DIFF
--- a/Sources/Sanity/SanityType+Image.swift
+++ b/Sources/Sanity/SanityType+Image.swift
@@ -75,11 +75,6 @@ extension SanityType.Image: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: ._type)
-        if type != "image" {
-            throw SanityType.SanityDecodingError.invalidType(type: type)
-        }
-
         let asset = try container.decode(SanityType.Ref.self, forKey: .asset)
         let crop = try? container.decode(Crop.self, forKey: .crop)
         let hotspot = try? container.decode(Hotspot.self, forKey: .hotspot)


### PR DESCRIPTION
It is quite common to extend the image model to a new named model to add fields. Example, where `image` is extended to `mainImage` and this is the `type` that is used around the schemas:

https://github.com/sanity-io/sanity-template-kitchen-sink/blob/main/template/studio/schemas/objects/mainImage.js#L2-L3

If the check if needed happy to find a better way. Maybe some assertions on the fields expected to be there like `asset`.