### PR TITLE
Adjustments to SanityClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,115 @@
 # Swift Sanity
 
-Code for interacting with Sanity content from Swift on iOS and macOS. This package is under development and may long term aim for feature parity with the [JavaScript client](https://www.sanity.io/docs/js-client), but for the time being is limited to Sanity asset pipeline URL generation.
+Code for interacting with Sanity content from Swift on iOS and macOS. This package is under development and may long term aim for feature parity with the [JavaScript client](https://www.sanity.io/docs/js-client), but for the time being is limited to groq queries, realtime listening and image asset url generation.
+
+## Queries
+
+You can perform queries with typed results, or untyped.
+
+### Typed results
+
+Simply pass in a type to the query function.
+
+```swift
+import Foundation
+import Sanity
+
+let client = SanityClient(projectId: "3do82whm", dataset: "next")
+
+// Our result type
+struct Post: Decodable {
+    let title: String
+    let slug: String?
+    let poster: SanityType.Image
+}
+
+var groq = """
+* [_type == "post"] {
+  title,
+  "slug": slug.current,
+  poster
+}[0...1]
+"""
+
+let query = client.query([Post].self, query: groq)
+
+let group = DispatchGroup()
+group.enter()
+
+query.fetch { completion in
+    switch(completion) {
+    case .success(let response):
+        dump(response.result)
+    case .failure(let error):
+        dump(error)
+    }
+    group.leave()
+}
+
+group.wait()
+```
+
+outputs
+```
+1 element
+  ▿ QueryTester.Post
+    - title: "Introducing Glush: a robust, human readable, top-down parser compiler"
+    ▿ slug: Optional("why-we-wrote-yet-another-parser-compiler")
+      - some: "why-we-wrote-yet-another-parser-compiler"
+    ▿ poster: Sanity.SanityType.Image
+      - id: "18b2c50584718e1356e696ab22a3499e4ba65b55"
+      - width: 5760
+      - height: 3840
+      - format: "png"
+      ▿ asset: Sanity.SanityType.Ref
+        - _ref: "image-18b2c50584718e1356e696ab22a3499e4ba65b55-5760x3840-png"
+        - _type: "reference"
+      - crop: nil
+      - hotspot: nil
+      - validImage: true
+```
+
+## Untyped results
+
+Omitting the type will return generic json
+
+```swift
+// ...
+let query = client.query(query: groq)
+
+query.fetch { completion in
+    switch(completion) {
+    case .success(let response):
+        print(response.result)
+    case .failure(let error):
+        dump(error)
+    }
+}
+```
+
+outputs
+```
+[
+  {
+    "slug" : "why-we-wrote-yet-another-parser-compiler",
+    "title" : "Introducing Glush: a robust, human readable, top-down parser compiler",
+    "poster" : {
+      "_type" : "image",
+      "asset" : {
+        "_type" : "reference",
+        "_ref" : "image-18b2c50584718e1356e696ab22a3499e4ba65b55-5760x3840-png"
+      },
+      "caption" : "Arrows on a green background"
+    }
+  }
+]
+```
+
+## Query Listening
+
+See the [example app](Example/SanityDemoApp/SanityDemoApp/ContentView.swift) for an example of listening to queries. This will push new results to you as content changes server side.
+
+[Sanity.io documentation on realtime updates](https://www.sanity.io/docs/realtime-updates)
 
 ## Generate image asset URLs
 

--- a/Sources/Sanity/SanityClient+Fetch.swift
+++ b/Sources/Sanity/SanityClient+Fetch.swift
@@ -25,40 +25,35 @@ public extension SanityClient.Query {
 
     struct ErrorResponse: Decodable {
         enum keys: String, CodingKey { case message, statusCode, error }
-        
+
         let message: String
         let statusCode: Int
         let errorMessage: String
-        
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: keys.self)
             self.message = try container.decode(String.self, forKey: .message)
             self.statusCode = try container.decode(Int.self, forKey: .statusCode)
             self.errorMessage = try container.decode(String.self, forKey: .error)
         }
-        
+
         struct Error: LocalizedError {
             var errorResponse: ErrorResponse
             init(response: ErrorResponse) {
                 self.errorResponse = response
             }
+
             var recoverySuggestion: String? {
-                get {
-                    return self.errorResponse.message
-                }
+                self.errorResponse.message
             }
-            
+
             var failureReason: String? {
-                get {
-                    return self.errorResponse.errorMessage
-                }
-            }            
-        }
-        
-        var error: Error {
-            get {
-                return Error(response: self)
+                self.errorResponse.errorMessage
             }
+        }
+
+        var error: Error {
+            Error(response: self)
         }
     }
 
@@ -71,9 +66,9 @@ public extension SanityClient.Query {
             }
 
             switch httpResponse.statusCode {
-            case 200..<300:
+            case 200 ..< 300:
                 return data
-            case 400..<500:
+            case 400 ..< 500:
                 let errorEnvelope = try JSONDecoder().decode(ErrorResponse.self, from: data)
                 throw errorEnvelope.error
             default:
@@ -87,29 +82,28 @@ public extension SanityClient.Query {
     func fetch(completion: @escaping ResultCallback<DataResponse<T>>) {
         let urlRequest = apiURL.fetch(query: query, params: params, config: config).urlRequest
 
-        let task = urlSession.dataTask(with: urlRequest) { data, response, error in
+        let task = urlSession.dataTask(with: urlRequest) { data, response, _ in
             guard let httpResponse = response as? HTTPURLResponse, let data = data else {
                 return completion(.failure(URLError(.badServerResponse)))
             }
-            
+
             let decoder = JSONDecoder()
-            
+
             switch httpResponse.statusCode {
-            case 200..<300:
+            case 200 ..< 300:
                 do {
                     let data = try decoder.decode(DataResponse<T>.self, from: data)
                     completion(.success(data))
                 } catch let e {
                     completion(.failure(e))
                 }
-            case 400..<500:
+            case 400 ..< 500:
                 if let errorEnvelope = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
                     return completion(.failure(errorEnvelope.error))
                 }
                 fallthrough
             default:
                 return completion(.failure(URLError(.badServerResponse)))
-                
             }
         }
 

--- a/Sources/Sanity/SanityClient+Fetch.swift
+++ b/Sources/Sanity/SanityClient+Fetch.swift
@@ -58,9 +58,9 @@ public extension SanityClient.Query {
     }
 
     func fetch() -> AnyPublisher<DataResponse<T>, Error> {
-        let url = apiURL.fetch(query: query, params: params, config: config).url
+        let urlRequest = apiURL.fetch(query: query, params: params, config: config).urlRequest
 
-        return urlSession.dataTaskPublisher(for: url).tryMap { data, response -> JSONDecoder.Input in
+        return urlSession.dataTaskPublisher(for: urlRequest).tryMap { data, response -> JSONDecoder.Input in
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw URLError(.badServerResponse)
             }
@@ -80,9 +80,9 @@ public extension SanityClient.Query {
     }
 
     func fetch(completion: @escaping ResultCallback<DataResponse<T>>) {
-        let url = apiURL.fetch(query: query, params: params, config: config).url
+        let urlRequest = apiURL.fetch(query: query, params: params, config: config).urlRequest
 
-        let task = urlSession.dataTask(with: url) { data, response, error in
+        let task = urlSession.dataTask(with: urlRequest) { data, response, error in
             guard let httpResponse = response as? HTTPURLResponse, let data = data else {
                 return completion(.failure(URLError(.badServerResponse)))
             }

--- a/Sources/Sanity/SanityClient+Listen.swift
+++ b/Sources/Sanity/SanityClient+Listen.swift
@@ -109,8 +109,9 @@ public extension SanityClient.Query {
     }
 
     func listen(reconnect: Bool = true) -> ListenPublisher<T> {
-        let url = apiURL.listen(query: query, params: params, config: config).url
-        let eventSource = EventSource(url: url)
+        let urlRequest = apiURL.listen(query: query, params: params, config: config).urlRequest
+        
+        let eventSource = EventSource(url: urlRequest.url!, headers: urlRequest.allHTTPHeaderFields ?? [:])
 
         eventSource.onMessage { id, event, data in
             print("message: \(String(describing: id)), event: \(String(describing: event)), data: \(String(describing: data))")

--- a/Sources/Sanity/SanityClient+Listen.swift
+++ b/Sources/Sanity/SanityClient+Listen.swift
@@ -110,7 +110,7 @@ public extension SanityClient.Query {
 
     func listen(reconnect: Bool = true) -> ListenPublisher<T> {
         let urlRequest = apiURL.listen(query: query, params: params, config: config).urlRequest
-        
+
         let eventSource = EventSource(url: urlRequest.url!, headers: urlRequest.allHTTPHeaderFields ?? [:])
 
         eventSource.onMessage { id, event, data in

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -22,10 +22,10 @@ public class SanityClient {
         let token: String?
         let useCdn: Bool?
         var apiHost: APIHost {
-            if useCdn == true && token == nil {
+            if useCdn == true, token == nil {
                 return .productionCDN
             }
-            
+
             return .production
         }
 
@@ -86,11 +86,11 @@ public class SanityClient {
         internal func getURLRequest(path: String = "/", queryItems: [URLQueryItem]? = nil) -> URLRequest {
             let url = getURL(path: path, queryItems: queryItems)
             var request = URLRequest(url: url)
-            
+
             if let token = self.token {
                 request.setValue("Bearer: \(token)", forHTTPHeaderField: "Authorization")
             }
-            
+
             return request
         }
     }
@@ -112,18 +112,17 @@ public class SanityClient {
                         .init(name: "query", value: query),
                     ] + self.parseParams(params)
 
-                    let paths: [String] = ["/", "data", "query", config.dataset]
-                    return config.getURLRequest(path: paths.joined(separator: "/"), queryItems: queryItems)
-                    
+                    let path = "/data/query/\(config.dataset)"
+                    return config.getURLRequest(path: path, queryItems: queryItems)
+
                 case let .listen(query, params, config):
                     let queryItems: [URLQueryItem] = [
                         .init(name: "query", value: query),
                         .init(name: "includeResult", value: "true"),
                     ] + parseParams(params)
 
-                    let paths: [String] = ["/", "data", "listen", config.dataset]
-                    return config.getURLRequest(path: paths.joined(separator: "/"), queryItems: queryItems)
-                    
+                    let path = "/data/listen/\(config.dataset)"
+                    return config.getURLRequest(path: path, queryItems: queryItems)
                 }
             }
 

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -55,7 +55,7 @@ public class SanityClient {
                 case .v1:
                     return "v1"
                 case .v20210325:
-                    return "v2020-03-25"
+                    return "v2021-03-25"
                 case .latest:
                     let formatter = DateFormatter()
                     formatter.dateFormat = "yyyy-MM-dd"

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -112,21 +112,21 @@ public class SanityClient {
             var urlRequest: URLRequest {
                 switch self {
                 case let .fetch(query, params, config):
-                    let queryItems = queryItems(defaults: [
+                    let items = queryItems(defaults: [
                         "query": query,
                     ], params: params)
 
                     let path = "/data/query/\(config.dataset)"
-                    return config.getURLRequest(path: path, queryItems: queryItems)
+                    return config.getURLRequest(path: path, queryItems: items)
 
                 case let .listen(query, params, config):
-                    let queryItems = queryItems(defaults: [
+                    let items = queryItems(defaults: [
                         "query": query,
                         "includeResult": "true",
                     ], params: params)
 
                     let path = "/data/listen/\(config.dataset)"
-                    return config.getURLRequest(path: path, queryItems: queryItems)
+                    return config.getURLRequest(path: path, queryItems: items)
                 }
             }
 

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -22,6 +22,10 @@ public class SanityClient {
         let token: String?
         let useCdn: Bool?
         var apiHost: APIHost {
+            // TODO: There are a few more conditions that will exclude CDN as a valid host, such as:
+            // config with custom apihost domain
+            // Any request that isnt GET or HEAD
+            // Query Listening?
             if useCdn == true, token == nil {
                 return .productionCDN
             }

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -92,7 +92,7 @@ public class SanityClient {
             var request = URLRequest(url: url)
 
             if let token = self.token {
-                request.setValue("Bearer: \(token)", forHTTPHeaderField: "Authorization")
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             }
 
             return request

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -108,21 +108,29 @@ public class SanityClient {
             var urlRequest: URLRequest {
                 switch self {
                 case let .fetch(query, params, config):
-                    let queryItems: [URLQueryItem] = [
-                        .init(name: "query", value: query),
-                    ] + self.parseParams(params)
+                    let queryItems = queryItems(defaults: [
+                        "query": query,
+                    ], params: params)
 
                     let path = "/data/query/\(config.dataset)"
                     return config.getURLRequest(path: path, queryItems: queryItems)
 
                 case let .listen(query, params, config):
-                    let queryItems: [URLQueryItem] = [
-                        .init(name: "query", value: query),
-                        .init(name: "includeResult", value: "true"),
-                    ] + parseParams(params)
-
+                    let queryItems = queryItems(defaults: [
+                        "query": query,
+                        "includeResult": "true"
+                    ], params: params)
+                    
                     let path = "/data/listen/\(config.dataset)"
                     return config.getURLRequest(path: path, queryItems: queryItems)
+                }
+            }
+            
+            private func queryItems(defaults: [String: Any], params: [String:Any]) -> [URLQueryItem] {
+                let mergedParams: [String: Any] = defaults.merging(params) { _, new in new }
+                
+                return mergedParams.map { key, value in
+                    URLQueryItem(name: key, value: String(describing: value))
                 }
             }
 

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -19,7 +19,7 @@ public class SanityClient {
         let projectId: String
         let dataset: String
         let version: APIVersion
-        let apiKey: String?
+        let token: String?
         let apiHost: APIHost = .productionCDN
 
         enum APIHost {
@@ -85,7 +85,7 @@ public class SanityClient {
                         .init(name: "query", value: query),
                     ] + self.parseParams(params)
 
-                    if let apiKey = config.apiKey {
+                    if let apiKey = config.token {
                         queryItems.append(.init(name: "apiKey", value: apiKey))
                     }
                     let paths: [String] = ["data", "query", config.dataset]
@@ -97,7 +97,7 @@ public class SanityClient {
                         .init(name: "includeResult", value: "true"),
                     ] + parseParams(params)
 
-                    if let apiKey = config.apiKey {
+                    if let apiKey = config.token {
                         queryItems.append(.init(name: "apiKey", value: apiKey))
                     }
 
@@ -125,7 +125,7 @@ public class SanityClient {
     }
 
     public init(projectId: String, dataset: String, version: Config.APIVersion = .v20210325, apiKey: String? = nil) {
-        self.config = Config(projectId: projectId, dataset: dataset, version: version, apiKey: apiKey)
+        self.config = Config(projectId: projectId, dataset: dataset, version: version, token: apiKey)
     }
 
     public func query<T: Decodable>(_: T.Type, query: String, params: [String: Any] = [:]) -> Query<T> {

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -22,9 +22,10 @@ public class SanityClient {
         let token: String?
         let useCdn: Bool?
         var apiHost: APIHost {
-            if useCdn == true {
+            if useCdn == true && token == nil {
                 return .productionCDN
             }
+            
             return .production
         }
 

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -118,17 +118,17 @@ public class SanityClient {
                 case let .listen(query, params, config):
                     let queryItems = queryItems(defaults: [
                         "query": query,
-                        "includeResult": "true"
+                        "includeResult": "true",
                     ], params: params)
-                    
+
                     let path = "/data/listen/\(config.dataset)"
                     return config.getURLRequest(path: path, queryItems: queryItems)
                 }
             }
-            
-            private func queryItems(defaults: [String: Any], params: [String:Any]) -> [URLQueryItem] {
+
+            private func queryItems(defaults: [String: Any], params: [String: Any]) -> [URLQueryItem] {
                 let mergedParams: [String: Any] = defaults.merging(params) { _, new in new }
-                
+
                 return mergedParams.map { key, value in
                     URLQueryItem(name: key, value: String(describing: value))
                 }

--- a/Tests/SanityTests/ImageUrlTests.swift
+++ b/Tests/SanityTests/ImageUrlTests.swift
@@ -283,4 +283,6 @@ final class SanityImageUrlTests: XCTestCase {
 
         assert(url.URL()!.absoluteString == "https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=240,300,720,2400&w=30&h=100")
     }
+
+    // TODO: Test overriding cdn hostname ala https://github.com/sanity-io/image-url/blob/f0a7b1430b64b2bb9ad9542a7b14e26bd905e3f5/test/fromClient.test.ts
 }

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -106,17 +106,17 @@ final class SanityClientQueryTests: XCTestCase {
             params: ["includeResult": false],
             config: config
         )
-        
+
         let url = listen.urlRequest.url!
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-        
+
         let query = components.queryItems?.first(where: { $0.name == "query" })?.value
         XCTAssertEqual(query, "*")
-        
+
         let includeResult = components.queryItems?.first(where: { $0.name == "includeResult" })?.value
         XCTAssertEqual(includeResult, "false")
     }
-    
+
     func testAddParams() {
         let config = SanityClient.Config(
             projectId: "rwmuledy",
@@ -134,10 +134,10 @@ final class SanityClientQueryTests: XCTestCase {
 
         let url = fetch.urlRequest.url!
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-        
+
         let kustom = components.queryItems?.first(where: { $0.name == "kustom" })?.value
         XCTAssertEqual(kustom, "29")
-        
+
         let another = components.queryItems?.first(where: { $0.name == "another" })?.value
         XCTAssertEqual(another, "one")
     }

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -1,0 +1,49 @@
+// MIT License
+//
+// Copyright (c) 2021 Sanity.io
+
+@testable import Sanity
+import XCTest
+
+final class SanityClientTests: XCTestCase {
+    func testConfig() {
+        let client = SanityClient(
+            projectId: "a",
+            dataset: "b",
+            version: .v20210325
+        )
+        
+        assert(client.config.projectId == "a")
+        assert(client.config.dataset == "b")
+        XCTAssertEqual(client.config.version.string, "v2021-03-25")
+    }
+    
+    // can use getURL() to get API-relative paths
+    func testGetURL() {
+        
+        let client = SanityClient(
+            projectId: "rwmuledy",
+            dataset: "b",
+            version: .v1
+        )
+        
+        XCTAssertEqual(client.getURL(path: "/bar/baz").absoluteString, "https://rwmuledy.api.sanity.io/v1/bar/baz")
+    }
+    
+    func testUseCdn() {
+        let client = SanityClient(
+            projectId: "rwmuledy",
+            dataset: "b",
+            version: .v1,
+            useCdn: true
+        )
+        
+        XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/")
+    }
+    
+    func testConfigInit() {
+        let config = SanityClient.Config(projectId: "rwmuledy", dataset: "master", version: .v1, token: nil, useCdn: false)
+        let client = SanityClient(config: config)
+        XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/")
+    }    
+}

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -12,24 +12,23 @@ final class SanityClientTests: XCTestCase {
             dataset: "b",
             version: .v20210325
         )
-        
+
         assert(client.config.projectId == "a")
         assert(client.config.dataset == "b")
         XCTAssertEqual(client.config.version.string, "v2021-03-25")
     }
-    
+
     // can use getURL() to get API-relative paths
     func testGetURL() {
-        
         let client = SanityClient(
             projectId: "rwmuledy",
             dataset: "b",
             version: .v1
         )
-        
+
         XCTAssertEqual(client.getURL(path: "/bar/baz").absoluteString, "https://rwmuledy.api.sanity.io/v1/bar/baz")
     }
-    
+
     func testUseCdn() {
         let client = SanityClient(
             projectId: "rwmuledy",
@@ -37,13 +36,13 @@ final class SanityClientTests: XCTestCase {
             version: .v1,
             useCdn: true
         )
-        
+
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/")
     }
-    
+
     func testConfigInit() {
         let config = SanityClient.Config(projectId: "rwmuledy", dataset: "master", version: .v1, token: nil, useCdn: false)
         let client = SanityClient(config: config)
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/")
-    }    
+    }
 }

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -58,13 +58,6 @@ final class SanityClientQueryTests: XCTestCase {
 
         let fetch = SanityClient.Query<String>.apiURL.fetch(query: "*", params: [:], config: config)
         XCTAssertEqual(fetch.urlRequest.url!.absoluteString, "https://rwmuledy.api.sanity.io/v1/data/query/prod?query=*")
-
-        let listen = SanityClient.Query<String>.apiURL.listen(query: "*", params: [:], config: config)
-
-        XCTAssertEqual(
-            listen.urlRequest.url!.absoluteString,
-            "https://rwmuledy.api.sanity.io/v1/data/listen/prod?query=*&includeResult=true"
-        )
     }
 
     func testQueryURLRequestAuthToken() {
@@ -113,10 +106,39 @@ final class SanityClientQueryTests: XCTestCase {
             params: ["includeResult": false],
             config: config
         )
-
-        XCTAssertEqual(
-            listen.urlRequest.url!.absoluteString,
-            "https://rwmuledy.api.sanity.io/v1/data/listen/prod?query=*&includeResult=false"
+        
+        let url = listen.urlRequest.url!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        
+        let query = components.queryItems?.first(where: { $0.name == "query" })?.value
+        XCTAssertEqual(query, "*")
+        
+        let includeResult = components.queryItems?.first(where: { $0.name == "includeResult" })?.value
+        XCTAssertEqual(includeResult, "false")
+    }
+    
+    func testAddParams() {
+        let config = SanityClient.Config(
+            projectId: "rwmuledy",
+            dataset: "prod",
+            version: .v1,
+            token: nil,
+            useCdn: nil
         )
+
+        let fetch = SanityClient.Query<String>.apiURL.fetch(
+            query: "*",
+            params: ["kustom": 29, "another": "one"],
+            config: config
+        )
+
+        let url = fetch.urlRequest.url!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        
+        let kustom = components.queryItems?.first(where: { $0.name == "kustom" })?.value
+        XCTAssertEqual(kustom, "29")
+        
+        let another = components.queryItems?.first(where: { $0.name == "another" })?.value
+        XCTAssertEqual(another, "one")
     }
 }

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -39,7 +39,7 @@ final class SanityClientTests: XCTestCase {
 
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/")
     }
-    
+
     func testNoCdnWithToken() {
         let client = SanityClient(projectId: "rwmuledy", dataset: "prod", version: .v1, token: "yes", useCdn: true)
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/", "Cannot use apicdn when token is set")

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -39,6 +39,11 @@ final class SanityClientTests: XCTestCase {
 
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/")
     }
+    
+    func testNoCdnWithToken() {
+        let client = SanityClient(projectId: "rwmuledy", dataset: "prod", version: .v1, token: "yes", useCdn: true)
+        XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/", "Cannot use apicdn when token is set")
+    }
 
     func testConfigInit() {
         let config = SanityClient.Config(projectId: "rwmuledy", dataset: "master", version: .v1, token: nil, useCdn: false)

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -51,3 +51,52 @@ final class SanityClientTests: XCTestCase {
         XCTAssertEqual(client.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/")
     }
 }
+
+final class SanityClientQueryTests: XCTestCase {
+    func testQueryURL() {
+        let config = SanityClient.Config(projectId: "rwmuledy", dataset: "prod", version: .v1, token: nil, useCdn: nil)
+
+        let fetch = SanityClient.Query<String>.apiURL.fetch(query: "*", params: [:], config: config)
+        XCTAssertEqual(fetch.urlRequest.url!.absoluteString, "https://rwmuledy.api.sanity.io/v1/data/query/prod?query=*")
+
+        let listen = SanityClient.Query<String>.apiURL.listen(query: "*", params: [:], config: config)
+
+        
+        XCTAssertEqual(
+            listen.urlRequest.url!.absoluteString,
+            "https://rwmuledy.api.sanity.io/v1/data/listen/prod?query=*&includeResult=true"
+        )
+    }
+
+    func testQueryURLRequestAuthToken() {
+        let config = SanityClient.Config(
+            projectId: "rwmuledy",
+            dataset: "prod",
+            version: .v1,
+            token: "ABC",
+            useCdn: nil
+        )
+
+        let fetch = SanityClient.Query<String>.apiURL.fetch(
+            query: "*",
+            params: [:],
+            config: config
+        )
+
+        XCTAssertEqual(
+            fetch.urlRequest.value(forHTTPHeaderField: "Authorization"),
+            "Bearer: ABC"
+        )
+
+        let listen = SanityClient.Query<String>.apiURL.listen(
+            query: "*",
+            params: [:],
+            config: config
+        )
+
+        XCTAssertEqual(
+            listen.urlRequest.value(forHTTPHeaderField: "Authorization"),
+            "Bearer: ABC"
+        )
+    }
+}

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -77,7 +77,7 @@ final class SanityClientQueryTests: XCTestCase {
 
         XCTAssertEqual(
             fetch.urlRequest.value(forHTTPHeaderField: "Authorization"),
-            "Bearer: ABC"
+            "Bearer ABC"
         )
 
         let listen = SanityClient.Query<String>.apiURL.listen(
@@ -88,7 +88,7 @@ final class SanityClientQueryTests: XCTestCase {
 
         XCTAssertEqual(
             listen.urlRequest.value(forHTTPHeaderField: "Authorization"),
-            "Bearer: ABC"
+            "Bearer ABC"
         )
     }
 

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -61,7 +61,6 @@ final class SanityClientQueryTests: XCTestCase {
 
         let listen = SanityClient.Query<String>.apiURL.listen(query: "*", params: [:], config: config)
 
-        
         XCTAssertEqual(
             listen.urlRequest.url!.absoluteString,
             "https://rwmuledy.api.sanity.io/v1/data/listen/prod?query=*&includeResult=true"
@@ -97,6 +96,27 @@ final class SanityClientQueryTests: XCTestCase {
         XCTAssertEqual(
             listen.urlRequest.value(forHTTPHeaderField: "Authorization"),
             "Bearer: ABC"
+        )
+    }
+
+    func testOverrideDefaultParams() {
+        let config = SanityClient.Config(
+            projectId: "rwmuledy",
+            dataset: "prod",
+            version: .v1,
+            token: nil,
+            useCdn: nil
+        )
+
+        let listen = SanityClient.Query<String>.apiURL.listen(
+            query: "*",
+            params: ["includeResult": false],
+            config: config
+        )
+
+        XCTAssertEqual(
+            listen.urlRequest.url!.absoluteString,
+            "https://rwmuledy.api.sanity.io/v1/data/listen/prod?query=*&includeResult=false"
         )
     }
 }


### PR DESCRIPTION
- Fix bug where year in version was wrong
- Add `useCdn`
- Add `getURL(path: String)`
- Rename apiKey -> `token`
- Let Config calculate base URLs
- Properly use `token` as HTTP request header
- Ensure we cannot use apicdn when `token` is set
- Allow overriding of default params
- More tests