### PR TITLE
fix: query-items in post request

### DIFF
--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -114,7 +114,7 @@ public class SanityClient {
             let url = getURL(path: path, queryItems: queryItems)
             if let queryItems, canUsePost, url.absoluteString.count > kQuerySizeLimitPost {
                 let body = try? JSONSerialization.data(withJSONObject: Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) }))
-                return getURLRequest(path: path, body: body, queryItems: queryItems)
+                return getURLRequest(path: path, body: body)
             }
 
             return getURLRequest(path: path, queryItems: queryItems)

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -56,6 +56,8 @@ final class SanityClientTests: XCTestCase {
         let request = SanityClient.Query<Any>.apiURL.fetch(query: query, params: [:], config: config).urlRequest
 
         XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/data/query/b?query=query!")
+        XCTAssertNil(request.httpBody)
     }
 
     func testUsePOST() {
@@ -72,6 +74,8 @@ final class SanityClientTests: XCTestCase {
         let request = SanityClient.Query<Any>.apiURL.fetch(query: query, params: [:], config: config).urlRequest
 
         XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://rwmuledy.apicdn.sanity.io/v1/data/query/b")
+        XCTAssertEqual(request.httpBody, Data("{\"query\":\"\(query)\"}".utf8))
     }
 
     func testNoCdnWithToken() {


### PR DESCRIPTION
We noticed that the query items are not removed in the case that the length limit is hit and the GET becomes a POST request; requests with long queries result in a 414 right now.

## Testing

I've extended some tests to check for that behavior and also confirmed in our project that the 414s no longer happen.