### PR TITLE
feat: return query

### DIFF
--- a/Example/SanityDemoApp/SanityDemoApp/ContentView.swift
+++ b/Example/SanityDemoApp/SanityDemoApp/ContentView.swift
@@ -68,7 +68,7 @@ class MoviesFetcher: ObservableObject {
     @Published var movies: [Movie] = []
     @Published var error: Error? = nil
     @Published var ms: Int = 0
-    @Published var queryString: String = ""
+    @Published var queryString: String?
 
     private var fetchMoviesCancellable: AnyCancellable?
     private var listenMoviesCancellable: AnyCancellable?
@@ -313,7 +313,7 @@ struct ContentView: View {
                     ErrorView(error: error)
                 } else {
                     HStack {
-                        Text("query: \(self.moviesFetcher.queryString.trimmingCharacters(in: .whitespacesAndNewlines))")
+                        Text("query: \(self.moviesFetcher.queryString?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")")
                         Spacer()
                     }
                     HStack {

--- a/Sources/Sanity/SanityClient+Fetch.swift
+++ b/Sources/Sanity/SanityClient+Fetch.swift
@@ -16,7 +16,9 @@ public extension SanityClient.Query where T: Decodable {
         public let ms: Int
 
         /// The submitted query
-        public let query: String
+        ///
+        /// If ``SanityClient.Config.returnQuery`` is set to false, this will be `nil`.
+        public let query: String?
 
         /// The query result
         public let result: R
@@ -25,7 +27,7 @@ public extension SanityClient.Query where T: Decodable {
             let container = try decoder.container(keyedBy: keys.self)
 
             self.ms = try container.decode(Int.self, forKey: .ms)
-            self.query = try container.decode(String.self, forKey: .query)
+            self.query = try container.decodeIfPresent(String.self, forKey: .query)
             self.result = try container.decode(R.self, forKey: .result)
         }
     }

--- a/Sources/Sanity/SanityClient.swift
+++ b/Sources/Sanity/SanityClient.swift
@@ -24,6 +24,7 @@ public class SanityClient {
         public let perspective: Perspective?
         public let token: String?
         public let useCdn: Bool
+        public let returnQuery: Bool
         
         public var apiHost: APIHost {
             // TODO: There are a few more conditions that will exclude CDN as a valid host, such as:
@@ -137,13 +138,22 @@ public class SanityClient {
             return getURLRequest(path: path, queryItems: queryItems)
         }
 
-        public init(projectId: String, dataset: String, version: APIVersion, perspective: Perspective?, useCdn: Bool, token: String?) {
+        public init(
+            projectId: String,
+            dataset: String,
+            version: APIVersion,
+            perspective: Perspective?,
+            useCdn: Bool,
+            token: String?,
+            returnQuery: Bool
+        ) {
             self.projectId = projectId
             self.dataset = dataset
             self.version = version
             self.perspective = perspective
             self.token = token
             self.useCdn = useCdn
+            self.returnQuery = returnQuery
         }
     }
 
@@ -163,6 +173,9 @@ public class SanityClient {
                     var items = [URLQueryItem(name: "query", value: query)]
                     if let perspective = config.perspective {
                         items.append(URLQueryItem(name: "perspective", value: perspective.rawValue))
+                    }
+                    if !config.returnQuery {
+                        items.append(URLQueryItem(name: "returnQuery", value: "false"))
                     }
                     addParams(params, to: &items)
 
@@ -246,8 +259,24 @@ public class SanityClient {
     /// - Warning: We encourage most users to use the api cdn for their front-ends unless there is a good reason not to.
     ///
     /// - Returns: SanityClient
-    public init(projectId: String, dataset: String, version: Config.APIVersion = .v20210325, perspective: Perspective? = nil, useCdn: Bool, token: String? = nil) {
-        self.config = Config(projectId: projectId, dataset: dataset, version: version, perspective: perspective, useCdn: useCdn, token: token)
+    public init(
+        projectId: String,
+        dataset: String,
+        version: Config.APIVersion = .v20210325,
+        perspective: Perspective? = nil,
+        useCdn: Bool,
+        token: String? = nil,
+        returnQuery: Bool = true
+    ) {
+        self.config = Config(
+            projectId: projectId,
+            dataset: dataset,
+            version: version,
+            perspective: perspective,
+            useCdn: useCdn,
+            token: token,
+            returnQuery: returnQuery
+        )
     }
 
     /// Constructs a groq query of type T

--- a/Tests/SanityTests/SanityClientMutationTests.swift
+++ b/Tests/SanityTests/SanityClientMutationTests.swift
@@ -13,7 +13,8 @@ final class SanityClientMutationTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: false,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
         let transaction = SanityClient.Transaction(config: config, mutations: [
             .createIfNotExists(document: [

--- a/Tests/SanityTests/SanityClientQueryTests.swift
+++ b/Tests/SanityTests/SanityClientQueryTests.swift
@@ -13,11 +13,12 @@ final class SanityClientQueryTests: XCTestCase {
             version: .v1,
             perspective: .raw,
             useCdn: false,
-            token: nil
+            token: nil,
+            returnQuery: false
         )
 
         let fetch = SanityClient.Query<String>.apiURL.fetch(query: "*", params: [:], config: config)
-        XCTAssertEqual(fetch.urlRequest.url?.absoluteString, "https://rwmuledy.api.sanity.io/v1/data/query/prod?query=*&perspective=raw")
+        XCTAssertEqual(fetch.urlRequest.url?.absoluteString, "https://rwmuledy.api.sanity.io/v1/data/query/prod?query=*&perspective=raw&returnQuery=false")
     }
 
     func testQueryURLRequestAuthToken() {
@@ -27,7 +28,8 @@ final class SanityClientQueryTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: false,
-            token: "ABC"
+            token: "ABC",
+            returnQuery: true
         )
 
         let fetch = SanityClient.Query<String>.apiURL.fetch(
@@ -63,7 +65,8 @@ final class SanityClientQueryTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: false,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
 
         let listen = SanityClient.Query<String>.apiURL.listen(
@@ -92,7 +95,8 @@ final class SanityClientQueryTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: false,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
 
         let fetch = SanityClient.Query<String>.apiURL.fetch(

--- a/Tests/SanityTests/SanityClientTests.swift
+++ b/Tests/SanityTests/SanityClientTests.swift
@@ -12,13 +12,15 @@ final class SanityClientTests: XCTestCase {
             dataset: "b",
             version: .v20210325,
             perspective: .published,
-            useCdn: true
+            useCdn: true,
+            returnQuery: false
         )
 
         XCTAssertEqual(client.config.projectId, "a")
         XCTAssertEqual(client.config.dataset, "b")
         XCTAssertEqual(client.config.version.string, "v2021-03-25")
         XCTAssertEqual(client.config.perspective, .published)
+        XCTAssertEqual(client.config.returnQuery, false)
     }
 
     // can use getURL() to get API-relative paths
@@ -51,7 +53,8 @@ final class SanityClientTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: true,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
 
         let query = String(repeating: "query!", count: 1)
@@ -70,7 +73,8 @@ final class SanityClientTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: true,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
 
         let query = String(repeating: "query!", count: 4000)
@@ -94,7 +98,8 @@ final class SanityClientTests: XCTestCase {
             version: .v1,
             perspective: nil,
             useCdn: false,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
         let client = SanityClient(config: config)
         XCTAssertEqual(client.config.getURL(path: "/").absoluteString, "https://rwmuledy.api.sanity.io/v1/")
@@ -108,23 +113,38 @@ final class SanityClientTests: XCTestCase {
         XCTAssertEqual(decodedImage, image)
     }
 
-    func testFileURL() throws {
+    func testFileURL() {
         let file = SanityType.File(asset: .init(_ref: "foo-bar-png", _type: "file"))
         let client = SanityClient(projectId: "rwmuledy", dataset: "some-dataset", version: .v1, useCdn: false)
         let url = client.fileURL(file)!
         XCTAssertEqual(url.absoluteString, "https://cdn.sanity.io/files/rwmuledy/some-dataset/bar.png")
     }
     
-    func testPerspective() throws {
+    func testPerspective() {
         let config = SanityClient.Config(
             projectId: "rwmuledy",
             dataset: "master",
             version: .v20250219,
             perspective: .drafts,
             useCdn: true,
-            token: nil
+            token: nil,
+            returnQuery: true
         )
         let request = SanityClient.Query<Any>.apiURL.fetch(query: "query!", params: [:], config: config).urlRequest
         XCTAssertEqual(request.url?.absoluteString, "https://rwmuledy.apicdn.sanity.io/v2025-02-19/data/query/master?query=query!&perspective=drafts")
+    }
+    
+    func testReturnQuery() {
+        let config = SanityClient.Config(
+            projectId: "rwmuledy",
+            dataset: "master",
+            version: .v20250219,
+            perspective: nil,
+            useCdn: true,
+            token: nil,
+            returnQuery: false
+        )
+        let request = SanityClient.Query<Any>.apiURL.fetch(query: "query!", params: [:], config: config).urlRequest
+        XCTAssertEqual(request.url?.absoluteString, "https://rwmuledy.apicdn.sanity.io/v2025-02-19/data/query/master?query=query!&returnQuery=false")
     }
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds support for the `returnQuery` option to not return the submitted query in the response.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I have added relevant unit tests and confirmed in our project that the query is nil when specified.